### PR TITLE
Custom options

### DIFF
--- a/battleship_runner.rb
+++ b/battleship_runner.rb
@@ -8,7 +8,7 @@ $computer = Computer.new
 
 def prompt_play
   option = $ui.determine_play
-  if option == :play
+  if option == :continue
     play_game
   end
 end

--- a/battleship_runner.rb
+++ b/battleship_runner.rb
@@ -17,8 +17,8 @@ end
 def play_game
   $ui.setup
   $computer.setup($ui.user_board, $ui.computer_board, $ui.computer_ships)
-  puts $ui.prompt_ship_placement
   $computer.place_ships
+  puts $ui.prompt_ship_placement
   $ui.determine_ship_placement
   until winner = $ui.winner do
     $ui.turn

--- a/battleship_runner.rb
+++ b/battleship_runner.rb
@@ -9,6 +9,7 @@ $computer = Computer.new
 def prompt_play
   option = $ui.determine_play
   if option == :continue
+    $ui.query_custom
     play_game
   end
 end

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -28,25 +28,22 @@ class UserInterface
     end
   end
 
-  def prompt_play
-    "Welcome to BATTLESHIP\nEnter p to play. Enter q to quit."
-  end
-
   def determine_play
-    puts prompt_play
-    until input = process_play(take_input(false)) do
-      puts "Please enter a valid option."
-    end
-    input
+    puts "Welcome to BATTLESHIP\nEnter 'p' to play. Enter 'q' to quit."
+    get_input("P", "Q")
   end
 
-  def process_play(input)
-    if input == "P"
-      :play
-    elsif input == "Q"
-      :quit
-    else
-      nil
+  def get_requested_input(continue_key, break_key)
+    loop do
+      input = gets.chomp.upcase
+      if input == continue_key
+        return :continue
+        break
+      elsif input == break_key
+        break
+      else
+        puts "Please enter a valid option."
+      end
     end
   end
 

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -39,16 +39,17 @@ class UserInterface
     get_requested_input("P", "Q")
   end
 
-  def get_requested_input(continue_key, break_key)
+  def get_requested_input(continue_key, break_key, message = "Please enter a valid option.")
     loop do
       input = gets.chomp.upcase
       if input == continue_key
         return :continue
         break
       elsif input == break_key
+        return :break
         break
       else
-        puts "Please enter a valid option."
+        puts message
       end
     end
   end
@@ -70,9 +71,9 @@ class UserInterface
 
   def custom_board
     print "Enter custom board width: "
-    @width = gets.chomp.to_i
+    @board_width = gets.chomp.to_i
     print "Enter custom board width: "
-    @height = gets.chomp.to_i
+    @board_height = gets.chomp.to_i
   end
 
   def custom_ships
@@ -83,16 +84,25 @@ class UserInterface
       name = gets.chomp.to_s.capitalize
       print "Enter #{name} length: "
       length = gets.chomp.to_i
+        until 1 < length && length < [@board_width, @board_height].max do
+          if length < 1
+            print "Length cannot be smaller than 1. Please enter another value: "
+            length = gets.chomp.to_i
+          elsif length > [@board_width, @board_height].max
+            print "Length exceeds board size. Please enter another value: "
+            length = gets.chomp.to_i
+          end
+        end
       @ships << [name, length]
       puts "Created custom ship #{name} with length #{length} units"
-      print "Enter 'c' to create another ship, or press 'd' for done."
+      puts "Enter 'c' to create another ship, or press 'd' for done."
       input = get_requested_input("D","C")
     end
   end
 
   def prompt_ship_placement
-    puts "I have laid out my ships on the grid.\n" +
-          "You now need to lay out your #{@user_ships.length} ships:"
+    "I have laid out my ships on the grid.\n" +
+    "You now need to lay out your #{@user_ships.length} ships:"
     @user_ships.map do |ship|
       "The #{ship.name} is #{ship.length} units long"
     end

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -22,6 +22,7 @@ class UserInterface
 
   def create_ships
     ships = []
+    @ships.sort_by! {|ship| -ship[-1]}
     2.times do
       ships << @ships.map do |ship|
         Ship.new(ship[0], ship[1])

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -91,13 +91,11 @@ class UserInterface
   end
 
   def prompt_ship_placement
-    output_str = "I have laid out my ships on the grid.\n"
-    output_str += "You now need to lay out your two ships\n" #CHANGE LATER
-    ship_info_str = ""
-    @user_ships.each do |ship|
-      ship_info_str += "the #{ship.name} is #{ship.length} units long and "
+    puts "I have laid out my ships on the grid.\n" +
+          "You now need to lay out your #{@user_ships.length} ships:"
+    @user_ships.map do |ship|
+      "The #{ship.name} is #{ship.length} units long"
     end
-    output_str + ship_info_str[0..-6].capitalize + "."
   end
 
   def determine_ship_placement #untestable due to input required in block

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -5,27 +5,33 @@ require './lib/cell.rb'
 class UserInterface
   attr_reader :user_board, :computer_board, :user_ships, :computer_ships
 
+  def initialize
+    @board_width = 4
+    @board_height = 4
+    @ships = [["Cruiser", 3], ["Sumbarine", 2]]
+  end
+
   def setup
-    board_pair = create_board(@default_board)
-    ships_pair = create_ships(@default_ships)
+    board_pair = create_board
+    ships_pair = create_ships
     @user_board = board_pair[0]
     @computer_board = board_pair[1]
     @user_ships = ships_pair[0]
     @computer_ships = ships_pair[1]
   end
 
-  def create_ships(defaults = true)
-    if defaults
-      [[Ship.new("Cruiser", 3), Ship.new("Sumbarine", 2)],[Ship.new("Cruiser", 3), Ship.new("Sumbarine", 2)]]
-    else
+  def create_ships
+    ships = []
+    2.times do
+      ships << @ships.map do |ship|
+        Ship.new(ship[0], ship[1])
+      end
     end
+    ships
   end
 
-  def create_board(defaults = true)
-    if defaults
-      [Board.new(4,4),Board.new(4,4)]
-    else
-    end
+  def create_board
+    [Board.new(@board_width,@board_height),Board.new(@board_width,@board_height)]
   end
 
   def determine_play
@@ -52,6 +58,7 @@ class UserInterface
     if get_requested_input("C","D") == :continue
       print "Choose board size? (y/n) "
       if get_requested_input("Y", "N") == :continue
+        @default_board = false
         custom_board
       end
       print "Create custom ships? (y/n) "
@@ -62,7 +69,6 @@ class UserInterface
   end
 
   def custom_board
-    @default_board = false
     print "Enter custom board width: "
     @width = gets.chomp.to_i
     print "Enter custom board width: "
@@ -70,7 +76,6 @@ class UserInterface
   end
 
   def custom_ships
-    @default_ships = false
     @ships = []
     input = ""
     until input == :continue

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -6,8 +6,8 @@ class UserInterface
   attr_reader :user_board, :computer_board, :user_ships, :computer_ships
 
   def setup
-    board_pair = create_board
-    ships_pair = create_ships
+    board_pair = create_board(@default_board)
+    ships_pair = create_ships(@default_ships)
     @user_board = board_pair[0]
     @computer_board = board_pair[1]
     @user_ships = ships_pair[0]
@@ -30,7 +30,7 @@ class UserInterface
 
   def determine_play
     puts "Welcome to BATTLESHIP\nEnter 'p' to play. Enter 'q' to quit."
-    get_input("P", "Q")
+    get_requested_input("P", "Q")
   end
 
   def get_requested_input(continue_key, break_key)
@@ -44,6 +44,44 @@ class UserInterface
       else
         puts "Please enter a valid option."
       end
+    end
+  end
+
+  def query_custom
+    puts "Enter 'd' to play with default settings,  or enter 'c' to create a custom board and ships."
+    if get_requested_input("C","D") == :continue
+      print "Choose board size? (y/n) "
+      if get_requested_input("Y", "N") == :continue
+        custom_board
+      end
+      print "Create custom ships? (y/n) "
+      if get_requested_input("Y", "N") == :continue
+        custom_ships
+      end
+    end
+  end
+
+  def custom_board
+    @default_board = false
+    print "Enter custom board width: "
+    @width = gets.chomp.to_i
+    print "Enter custom board width: "
+    @height = gets.chomp.to_i
+  end
+
+  def custom_ships
+    @default_ships = false
+    @ships = []
+    input = ""
+    until input == :continue
+      print "Enter custom ship name: "
+      name = gets.chomp.to_s.capitalize
+      print "Enter #{name} length: "
+      length = gets.chomp.to_i
+      @ships << [name, length]
+      puts "Created custom ship #{name} with length #{length} units"
+      print "Enter 'c' to create another ship, or press 'd' for done."
+      input = get_requested_input("D","C")
     end
   end
 

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -84,17 +84,21 @@ class UserInterface
       name = gets.chomp.to_s.capitalize
       print "Enter #{name} length: "
       length = gets.chomp.to_i
-        until 1 < length && length < [@board_width, @board_height].max do
-          if length < 1
-            print "Length cannot be smaller than 1. Please enter another value: "
-            length = gets.chomp.to_i
-          elsif length > [@board_width, @board_height].max
-            print "Length exceeds board size. Please enter another value: "
-            length = gets.chomp.to_i
-          end
+      until 0 < length && length <= [@board_width, @board_height].max do
+        if length < 1
+          print "Length cannot be smaller than 1. Please enter another value: "
+          length = gets.chomp.to_i
+        elsif length > [@board_width, @board_height].max
+          print "Length exceeds board size. Please enter another value: "
+          length = gets.chomp.to_i
         end
-      @ships << [name, length]
-      puts "Created custom ship #{name} with length #{length} units"
+      end
+      if (length + @ships.sum {|ship| ship[1]}) > (@board_width * @board_height)
+        puts "There is not enough space left on the board for a ship of this length. #{name} cannot be created."
+      else
+        @ships << [name, length]
+        puts "Created custom ship #{name} with length #{length} units"
+      end
       puts "Enter 'c' to create another ship, or press 'd' for done."
       input = get_requested_input("D","C")
     end

--- a/test/user_interface_test.rb
+++ b/test/user_interface_test.rb
@@ -27,8 +27,4 @@ class UserInterfaceTest < Minitest::Test
     assert @ui.user_board != @computer.board
   end
 
-  def test_it_prompts_play
-    assert_equal "Welcome to BATTLESHIP\nEnter p to play. Enter q to quit.", @ui.prompt_play
-  end
-
 end

--- a/test/user_interface_test.rb
+++ b/test/user_interface_test.rb
@@ -1,4 +1,5 @@
 require './lib/user_interface.rb'
+require './lib/computer'
 require './lib/board.rb'
 require './lib/ship.rb'
 
@@ -7,34 +8,27 @@ require 'minitest/pride'
 
 class UserInterfaceTest < Minitest::Test
   def setup
-    @player_board = Board.new(4,4)
-    @computer_board = Board.new(4,4)
-    @player_ships = [
-      Ship.new("Cruiser",3),
-      Ship.new("Submarine",2)
-    ]
-    @computer_ships = [
-      Ship.new("Cruiser",3),
-      Ship.new("Submarine",2)
-    ]
-    @ui = UserInterface.new(@player_board,@computer_board,@player_ships,@computer_ships)
+    @ui = UserInterface.new
+    @ui.setup
+    @computer = Computer.new
+    @computer.setup(@ui.user_board, @ui.computer_board, @ui.computer_ships)
   end
 
   def test_it_exists
-    require "pry";binding.pry
     assert_instance_of UserInterface, @ui
   end
 
-  def test_it_has_attributes
-    assert_equal @player_ships, @ui.player_ships
-    assert_equal @computer_ships, @ui.computer_ships
-    assert_equal @player_board, @ui.player_board
-    assert_equal @computer_board, @ui.computer_board
+  def test_it_creates_separate_objects_for_user_and_computer
+    assert_instance_of Ship, @ui.user_ships[0]
+    assert_instance_of Ship, @ui.computer_ships[0]
+    assert_instance_of Board, @ui.user_board
+    assert_instance_of Board, @ui.computer_board
+    assert @ui.user_board != @ui.computer_board
+    assert @ui.user_board != @computer.board
   end
 
   def test_it_prompts_play
-    assert_equal "Welcome to BATTLESHIP\nEnter p to play. Enter q to quit.",@ui.prompt_play
+    assert_equal "Welcome to BATTLESHIP\nEnter p to play. Enter q to quit.", @ui.prompt_play
   end
-
 
 end


### PR DESCRIPTION
This branch adds the code needed to enter a custom board size or custom ships. It will need a good bit of cleaning up; in particular, the method to get custom ship info is massive and will need at least one helper method. It may be worth considering creating a custom_options class that the UI can delegate that work to. I think I remember one of the instructors saying that classes should be under 100 lines of code and the UI is over twice that (although I may be misremembering and/or making that up). I tried to limit the custom ships input to ships that would fit on the board, but there are probably some additional edge cases to consider. For now, though, everything is functional.